### PR TITLE
fix: remove unnecessary trailing space from formatted time

### DIFF
--- a/crates/lib/src/lib.rs
+++ b/crates/lib/src/lib.rs
@@ -186,7 +186,7 @@ fn format_remaining_time(remaining_time: Duration) -> String {
             } else {
                 unit
             };
-            formatted_time.push_str(&format!("{value} {unit_str} "));
+            formatted_time.push_str(&format!("{value} {unit_str}"));
         }
     }
 


### PR DESCRIPTION
This will change the text from this:

`Account locked! Unlocking in 30 seconds .`

to:

`Account locked! Unlocking in 30 seconds.`
