### PR TITLE
fix: tally file permissions 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -556,6 +556,7 @@ name = "lib"
 version = "0.9.2"
 dependencies = [
  "chrono",
+ "libc",
  "log",
  "pam-bindings",
  "tempdir",
@@ -958,18 +959,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.195"
+version = "1.0.196"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63261df402c67811e9ac6def069e4786148c4563f4b50fd4bf30aa370d626b02"
+checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.195"
+version = "1.0.196"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46fe8f8603d81ba86327b23a2e9cdf49e1255fb94a4c5f297f6ee0547178ea2c"
+checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -978,9 +979,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.111"
+version = "1.0.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "176e46fa42316f18edd598015a5166857fc835ec732f5215eac6b7bdbf0a84f4"
+checksum = "4d1bd37ce2324cf3bf85e5a25f96eb4baf0d5aa6eba43e7ae8958870c4ec48ed"
 dependencies = [
  "itoa",
  "ryu",
@@ -1558,9 +1559,9 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"
-version = "0.5.34"
+version = "0.5.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7cf47b659b318dccbd69cc4797a39ae128f533dce7902a1096044d1967b9c16"
+checksum = "1931d78a9c73861da0134f453bb1f790ce49b2e30eba8410b4b79bac72b46a2d"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,16 +212,16 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.31"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
+checksum = "9f13690e35a5e4ace198e7beea2895d29f3a9cc55015fcebe6336bd2010af9eb"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "wasm-bindgen",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.0",
 ]
 
 [[package]]
@@ -844,7 +844,7 @@ checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.4",
+ "regex-automata 0.4.5",
  "regex-syntax 0.8.2",
 ]
 
@@ -859,9 +859,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b7fa1134405e2ec9353fd416b17f8dacd46c473d7d3fd1cf202706a14eb792a"
+checksum = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ chrono = "0.4.31"
 clap = { version = "4.4.16", features = ["derive"] }
 cli-xtask = { version = "0.8.0", features = ["main", "lib-crate"] }
 colored = "2.1.0"
+libc = "0.2.152"
 log = "0.4"
 pam-bindings = "0.1.1"
 pam-client = "0.5.0"
@@ -64,3 +65,5 @@ assets = [
 
 [lints]
 workspace = true
+
+[dependencies]

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -16,6 +16,7 @@ doc = false
 
 [dependencies]
 chrono.workspace = true
+libc.workspace = true
 log.workspace = true
 pam-bindings.workspace = true
 toml.workspace = true

--- a/crates/lib/src/lib.rs
+++ b/crates/lib/src/lib.rs
@@ -104,7 +104,7 @@ impl PamHooks for Pamauthramp {
                 Actions::AUTHSUCC => Err(PamResultCode::PAM_AUTH_ERR),
             }
         })
-        .unwrap_or(PamResultCode::PAM_SUCCESS)
+        .unwrap_or_else(|e| e)
     }
 
     /// Handles the `acct_mgmt` PAM hook, which is invoked during the account management process.

--- a/crates/util/src/settings.rs
+++ b/crates/util/src/settings.rs
@@ -183,6 +183,6 @@ mod tests {
         let flags: PamFlag = 0;
         let result = Settings::build(None, &args, flags, "test");
         assert!(result.is_err());
-        assert_eq!(result.unwrap_err(), PamResultCode::PAM_SYSTEM_ERR);
+        assert_eq!(result.unwrap_err(), PamResultCode::PAM_USER_UNKNOWN);
     }
 }

--- a/crates/util/src/settings.rs
+++ b/crates/util/src/settings.rs
@@ -110,7 +110,7 @@ impl Settings<'_> {
         settings.action.get_or_insert(Actions::AUTHSUCC);
 
         // get user
-        settings.user = Some(user.ok_or(PamResultCode::PAM_SYSTEM_ERR)?);
+        settings.user = Some(user.ok_or(PamResultCode::PAM_USER_UNKNOWN)?);
 
         // pam hook
         settings.pam_hook = pam_hook;

--- a/crates/xtask-test-integration/src/main.rs
+++ b/crates/xtask-test-integration/src/main.rs
@@ -1,4 +1,4 @@
-//! # XTask Module
+//! # `XTask` Module
 //!
 //! The `xtask` module provides a set of development tasks and commands for managing
 //! the `pam-authramp` project during development. It utilizes the `xshell` crate for

--- a/tests/test-pam-auth.rs
+++ b/tests/test-pam-auth.rs
@@ -113,8 +113,9 @@ mod test_pam_auth {
             assert!(tally_file_path.exists(), "Tally file not created");
 
             // Expect tally count
-            let ini_content = fs::read_to_string(tally_file_path).unwrap();
-            assert!(ini_content.contains(&format!("count = {total_tries}")));
+            let toml_content = fs::read_to_string(tally_file_path).unwrap();
+            println!("{toml_content}");
+            assert!(toml_content.contains(&format!("count = {total_tries}")));
         });
     }
 
@@ -132,9 +133,9 @@ mod test_pam_auth {
             assert!(tally_file_path.exists(), "Tally file not created");
 
             // Expect tally count to increase
-            let ini_content = fs::read_to_string(&tally_file_path).unwrap();
+            let toml_content = fs::read_to_string(&tally_file_path).unwrap();
             assert!(
-                ini_content.contains("count = 1"),
+                toml_content.contains("count = 1"),
                 "Expected tally count to increase"
             );
 
@@ -148,9 +149,9 @@ mod test_pam_auth {
                 .expect("Account management failed");
 
             // Expect tally count to decrease
-            let ini_content = fs::read_to_string(&tally_file_path).unwrap();
+            let toml_content = fs::read_to_string(&tally_file_path).unwrap();
             assert!(
-                ini_content.contains("count = 0"),
+                toml_content.contains("count = 0"),
                 "Expected tally count = 0"
             );
         });


### PR DESCRIPTION
- set tally file permissions to user
- return clearer pam result codes
- update dependencies
